### PR TITLE
Update AuthService.js

### DIFF
--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -38,8 +38,8 @@ async function refreshAuthToken(config) {
     await AuthService.loginWithPopup()
   } else if (needsRefresh) {
     await AuthService.getTokenSilently()
+    api.defaults.headers.authorization = AuthService.bearer
+    socketService.authenticate(AuthService.bearer)
   }
-  api.defaults.headers.authorization = AuthService.bearer
-  socketService.authenticate(AuthService.bearer)
   return config
 }


### PR DESCRIPTION
Having this outside of the else if triggers socket authentication on each request. This is due to the interceptor fired on every request re-authenticates the socket. This should only be done if the token is refreshed, or they re-login (the re-login triggers the AUTHENTICATED event, and therefore only the refresh needs it.